### PR TITLE
docs: add NOTICE file for Apache 2.0 compliance

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,7 @@
+ovh-ikvm-mcp
+Copyright 2025 ovh-ikvm-mcp contributors
+
+This product connects to BMC (Baseboard Management Controller) firmware
+by American Megatrends Inc. (https://www.ami.com/) and downloads the
+AST2500 video decoder at runtime from the BMC's web interface. The
+decoder is not distributed with this project.


### PR DESCRIPTION
## Summary
- Adds Apache 2.0 required NOTICE file
- Acknowledges runtime dependency on AMI's AST2500 video decoder
- Clarifies the decoder is fetched at runtime, not distributed with the project

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun test` passes (70 pass, 5 skip, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Add a NOTICE file describing the AMI AST2500 video decoder runtime dependency and clarifying it is fetched at runtime rather than distributed with the project.