### PR TITLE
chore: add SPDX license headers to all source and test files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 ovh-ikvm-mcp contributors
+
 /**
  * Entry point — starts the MCP server with Streamable HTTP transport.
  */

--- a/src/kvm/bmc-session.ts
+++ b/src/kvm/bmc-session.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 ovh-ikvm-mcp contributors
+
 /**
  * BMC session establishment for AMI/ASRockRack firmware.
  *

--- a/src/kvm/decoder-fetcher.ts
+++ b/src/kvm/decoder-fetcher.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 ovh-ikvm-mcp contributors
+
 /**
  * Runtime fetcher for the AST2500 video decoder from BMC firmware.
  *

--- a/src/kvm/optimize.ts
+++ b/src/kvm/optimize.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 ovh-ikvm-mcp contributors
+
 /**
  * Post-processing to make KVM screenshots readable by LLM vision.
  *

--- a/src/kvm/screenshot.ts
+++ b/src/kvm/screenshot.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 ovh-ikvm-mcp contributors
+
 /**
  * KVM screenshot capture via AMI/ASRockRack IVTP WebSocket protocol.
  *

--- a/src/kvm/types.ts
+++ b/src/kvm/types.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 ovh-ikvm-mcp contributors
+
 /**
  * Types for AMI/ASRockRack KVM WebSocket protocol.
  */

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 ovh-ikvm-mcp contributors
+
 /**
  * MCP server setup with tool definitions.
  */

--- a/src/providers/ovh/api.ts
+++ b/src/providers/ovh/api.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 ovh-ikvm-mcp contributors
+
 /**
  * OVH API client with request signing.
  */

--- a/src/providers/ovh/provider.ts
+++ b/src/providers/ovh/provider.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 ovh-ikvm-mcp contributors
+
 /**
  * OVH provider — implements the Provider interface for OVH dedicated servers.
  */

--- a/src/providers/ovh/types.ts
+++ b/src/providers/ovh/types.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 ovh-ikvm-mcp contributors
+
 /**
  * OVH API types.
  */

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 ovh-ikvm-mcp contributors
+
 /**
  * Provider interface — abstraction over bare metal server providers.
  * Each provider (OVH, Hetzner, etc.) implements this interface.

--- a/src/vnc/encodings.ts
+++ b/src/vnc/encodings.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 ovh-ikvm-mcp contributors
+
 /**
  * RFB framebuffer encoding decoders.
  */

--- a/src/vnc/rfb-client.ts
+++ b/src/vnc/rfb-client.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 ovh-ikvm-mcp contributors
+
 /**
  * Minimal RFB (VNC) protocol client for screenshot capture.
  * Connects via WebSocket, performs handshake, and captures framebuffer.

--- a/src/vnc/screenshot.ts
+++ b/src/vnc/screenshot.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 ovh-ikvm-mcp contributors
+
 /**
  * High-level screenshot capture from a VNC/RFB server over WebSocket.
  */

--- a/src/vnc/types.ts
+++ b/src/vnc/types.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 ovh-ikvm-mcp contributors
+
 /**
  * RFB (Remote Framebuffer) protocol types.
  * Based on RFC 6143 — The Remote Framebuffer Protocol.

--- a/test/helpers/mock-bmc-server.ts
+++ b/test/helpers/mock-bmc-server.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 ovh-ikvm-mcp contributors
+
 /**
  * Mock ASRockRack/AMI BMC server for testing.
  *

--- a/test/helpers/mock-ovh-api.ts
+++ b/test/helpers/mock-ovh-api.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 ovh-ikvm-mcp contributors
+
 /**
  * Mock OVH API server for testing.
  * Simulates OVH API endpoints with proper header validation.

--- a/test/helpers/vnc-server.ts
+++ b/test/helpers/vnc-server.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 ovh-ikvm-mcp contributors
+
 /**
  * Minimal VNC/RFB server for testing.
  * Serves a known test image over WebSocket using the RFB protocol.

--- a/test/integration/mcp-live.test.ts
+++ b/test/integration/mcp-live.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 ovh-ikvm-mcp contributors
+
 /**
  * Live integration test: exercises the full MCP server against a real OVH account.
  *

--- a/test/kvm/bmc-session.test.ts
+++ b/test/kvm/bmc-session.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 ovh-ikvm-mcp contributors
+
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { establishBmcSession } from "../../src/kvm/bmc-session.js";
 import { MockBmcServer } from "../helpers/mock-bmc-server.js";

--- a/test/kvm/decoder-fetcher.test.ts
+++ b/test/kvm/decoder-fetcher.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 ovh-ikvm-mcp contributors
+
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import { clearDecoderCache, fetchDecoder } from "../../src/kvm/decoder-fetcher.js";
 

--- a/test/kvm/optimize.test.ts
+++ b/test/kvm/optimize.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 ovh-ikvm-mcp contributors
+
 import { describe, expect, it } from "bun:test";
 import { PNG } from "pngjs";
 import { optimizeForLlm } from "../../src/kvm/optimize.js";

--- a/test/kvm/screenshot.test.ts
+++ b/test/kvm/screenshot.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 ovh-ikvm-mcp contributors
+
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import { clearDecoderCache } from "../../src/kvm/decoder-fetcher.js";
 import { captureKvmScreenshot } from "../../src/kvm/screenshot.js";

--- a/test/mcp/server.test.ts
+++ b/test/mcp/server.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 ovh-ikvm-mcp contributors
+
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";

--- a/test/providers/ovh/api.test.ts
+++ b/test/providers/ovh/api.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 ovh-ikvm-mcp contributors
+
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { OvhApiClient } from "../../../src/providers/ovh/api.js";
 import { MockOvhApi } from "../../helpers/mock-ovh-api.js";

--- a/test/providers/ovh/provider.test.ts
+++ b/test/providers/ovh/provider.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 ovh-ikvm-mcp contributors
+
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { OvhProvider } from "../../../src/providers/ovh/provider.js";
 import { MockBmcServer } from "../../helpers/mock-bmc-server.js";

--- a/test/vnc/rfb-client.test.ts
+++ b/test/vnc/rfb-client.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 ovh-ikvm-mcp contributors
+
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { RfbClient } from "../../src/vnc/rfb-client.js";
 import { TestVncServer } from "../helpers/vnc-server.js";

--- a/test/vnc/screenshot.test.ts
+++ b/test/vnc/screenshot.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 ovh-ikvm-mcp contributors
+
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { PNG } from "pngjs";
 import { captureScreenshot, framebufferToPng } from "../../src/vnc/screenshot.js";


### PR DESCRIPTION
## Summary
- Adds `SPDX-License-Identifier: Apache-2.0` and `SPDX-FileCopyrightText` headers to all 28 TypeScript files under `src/` and `test/`
- Moves toward REUSE compliance

## Checklist
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun test` passes (70 pass, 5 skip, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Chores:
- Add standard Apache-2.0 SPDX license and copyright headers to all TypeScript source files under src/ and test/.