### PR TITLE
chore: harden CI with pinned action SHAs and least-privilege permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,16 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
         with:
           bun-version: latest
 


### PR DESCRIPTION
## Summary
- Pin `actions/checkout` and `oven-sh/setup-bun` to full commit SHAs to prevent supply chain attacks via tag rewriting
- Add `permissions: contents: read` for least-privilege CI execution

## Checklist
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun test` passes (70 pass, 5 skip, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden the CI workflow by restricting default permissions and pinning third-party GitHub Actions to specific commit SHAs for improved supply-chain security.

CI:
- Add least-privilege workflow permissions by granting read-only access to repository contents.
- Pin actions/checkout and oven-sh/setup-bun GitHub Actions to specific commit SHAs in the CI workflow.