### PR TITLE
fix: address accepted sourcery-ai review findings

### DIFF
--- a/src/kvm/decoder-fetcher.ts
+++ b/src/kvm/decoder-fetcher.ts
@@ -14,6 +14,8 @@
  * - Zero extra setup for users
  */
 
+const DEFAULT_DECODER_FETCH_TIMEOUT = 10_000;
+
 /** Decoder factory: returns a new decoder instance when called. */
 // biome-ignore lint/suspicious/noExplicitAny: vendored decoder has no type definitions
 type DecoderFactory = () => any;
@@ -65,6 +67,7 @@ export async function fetchDecoder(
 	const url = `${protocol}//${host}/libs/kvm/ast/decode_worker.js`;
 	const res = await fetch(url, {
 		headers: { Cookie: `QSESSIONID=${sessionCookie}` },
+		signal: AbortSignal.timeout(DEFAULT_DECODER_FETCH_TIMEOUT),
 	});
 
 	if (!res.ok) {

--- a/src/kvm/screenshot.ts
+++ b/src/kvm/screenshot.ts
@@ -177,6 +177,16 @@ async function captureVideoFrame(
 		let receivedCompressedBytes = 0;
 		let isFirstPacket = true;
 
+		// biome-ignore lint: Bun's WebSocket supports headers option (non-standard)
+		const ws = new (WebSocket as any)(wsUrl, {
+			headers: {
+				Cookie: `QSESSIONID=${session.sessionCookie}`,
+				Origin: `https://${session.host}`,
+				"Sec-WebSocket-Protocol": "binary, base64",
+			},
+		});
+		ws.binaryType = "arraybuffer";
+
 		const finish = (err: Error | null, frame?: VideoFrame): void => {
 			if (settled) return;
 			settled = true;
@@ -199,16 +209,6 @@ async function captureVideoFrame(
 		const frameTimer = setTimeout(() => {
 			finish(new Error(`No complete video frame received within ${frameTimeout}ms`));
 		}, frameTimeout);
-
-		// biome-ignore lint: Bun's WebSocket supports headers option (non-standard)
-		const ws = new (WebSocket as any)(wsUrl, {
-			headers: {
-				Cookie: `QSESSIONID=${session.sessionCookie}`,
-				Origin: `https://${session.host}`,
-				"Sec-WebSocket-Protocol": "binary, base64",
-			},
-		});
-		ws.binaryType = "arraybuffer";
 
 		ws.onopen = (): void => {
 			connected = true;

--- a/test/kvm/decoder-fetcher.test.ts
+++ b/test/kvm/decoder-fetcher.test.ts
@@ -101,13 +101,15 @@ describe("fetchDecoder", () => {
 			},
 		});
 
-		const host2 = `localhost:${server2.port}`;
+		try {
+			const host2 = `localhost:${server2.port}`;
 
-		const factory1 = await fetchDecoder(host, sessionCookie, "http:");
-		const factory2 = await fetchDecoder(host2, "any-cookie", "http:");
-		expect(factory1).not.toBe(factory2);
-
-		server2.stop(true);
+			const factory1 = await fetchDecoder(host, sessionCookie, "http:");
+			const factory2 = await fetchDecoder(host2, "any-cookie", "http:");
+			expect(factory1).not.toBe(factory2);
+		} finally {
+			server2.stop(true);
+		}
 	});
 
 	it("should clear cache when clearDecoderCache is called", async () => {
@@ -131,12 +133,14 @@ describe("fetchDecoder error handling", () => {
 			},
 		});
 
-		const host = `localhost:${server.port}`;
-		await expect(fetchDecoder(host, "cookie", "http:")).rejects.toThrow(
-			/Failed to fetch decoder.*500/,
-		);
-
-		server.stop(true);
+		try {
+			const host = `localhost:${server.port}`;
+			await expect(fetchDecoder(host, "cookie", "http:")).rejects.toThrow(
+				/Failed to fetch decoder.*500/,
+			);
+		} finally {
+			server.stop(true);
+		}
 	});
 
 	it("should throw when the fetched JS is not valid JavaScript", async () => {
@@ -149,12 +153,14 @@ describe("fetchDecoder error handling", () => {
 			},
 		});
 
-		const host = `localhost:${server.port}`;
-		await expect(fetchDecoder(host, "cookie", "http:")).rejects.toThrow(
-			/Failed to initialize decoder/,
-		);
-
-		server.stop(true);
+		try {
+			const host = `localhost:${server.port}`;
+			await expect(fetchDecoder(host, "cookie", "http:")).rejects.toThrow(
+				/Failed to initialize decoder/,
+			);
+		} finally {
+			server.stop(true);
+		}
 	});
 
 	it("should throw when the fetched JS does not define a Decoder constructor", async () => {
@@ -167,12 +173,14 @@ describe("fetchDecoder error handling", () => {
 			},
 		});
 
-		const host = `localhost:${server.port}`;
-		await expect(fetchDecoder(host, "cookie", "http:")).rejects.toThrow(
-			/Failed to initialize decoder/,
-		);
-
-		server.stop(true);
+		try {
+			const host = `localhost:${server.port}`;
+			await expect(fetchDecoder(host, "cookie", "http:")).rejects.toThrow(
+				/Failed to initialize decoder/,
+			);
+		} finally {
+			server.stop(true);
+		}
 	});
 
 	it("should throw when the server is unreachable", async () => {


### PR DESCRIPTION
## Summary

- Reorder `ws` declaration before `finish` closure in `screenshot.ts` to make the dependency explicit (eliminates TDZ reliance)
- Add `AbortSignal.timeout(10s)` to decoder fetch in `decoder-fetcher.ts` to prevent indefinite hangs when BMC is slow/unresponsive
- Wrap per-test server cleanup in `try/finally` in `decoder-fetcher.test.ts` to prevent port leaks on assertion failure

Closes #21

## Context

A Staff TypeScript engineer reviewed all 8 sourcery-ai bot comments across PRs #3–#6 and accepted 3 as reasonable:

| Severity | File | Issue |
|----------|------|-------|
| minor | `src/kvm/screenshot.ts` | `finish` closure references `ws` before declaration |
| **important** | `src/kvm/decoder-fetcher.ts` | `fetch()` has no timeout — can hang indefinitely |
| minor | `test/kvm/decoder-fetcher.test.ts` | Per-test servers leak on assertion failure |

5 comments were rejected (factually wrong, style nitpicks, or not worth fixing).

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun test` — 70 pass, 5 skip, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Address WebSocket initialization ordering and add robustness to decoder fetching and its tests.

Bug Fixes:
- Ensure WebSocket is constructed before closures that reference it in screenshot capture logic to avoid relying on temporal dead zone behavior.
- Add a timeout to decoder script fetches to prevent requests from hanging indefinitely when the BMC is slow or unresponsive.
- Guarantee test HTTP servers are stopped even when assertions fail to prevent port leaks in decoder fetcher tests.

Tests:
- Wrap decoder fetcher test server usage in try/finally blocks to ensure reliable cleanup across all relevant test cases.